### PR TITLE
Fix gp/product URL case

### DIFF
--- a/amazon.js
+++ b/amazon.js
@@ -8,5 +8,11 @@
 // @grant       none
 // ==/UserScript==
 
-history.pushState('','',location.href.match(/\/dp\/.{10}/));
-history.pushState('','',location.href.match(/\/gp\/product\/.{10}/));
+(function() {
+  const dp = location.href.match(/\/dp\/([A-Z0-9]{10})/i);
+  const gp = location.href.match(/\/gp\/product\/([A-Z0-9]{10})/i);
+  const asin = (dp && dp[1]) || (gp && gp[1]);
+  if (asin) {
+    history.replaceState('', '', `/dp/${asin}`);
+  }
+})();


### PR DESCRIPTION
## Summary
- handle `/gp/product/` links the same as `/dp/`
- normalize either URL form to `/dp/{ASIN}`

## Testing
- `node -e "const url='https://www.amazon.co.jp/gp/product/B012345678/ref=abc';const dp=url.match(/\/dp\/([A-Z0-9]{10})/i);const gp=url.match(/\/gp\/product\/([A-Z0-9]{10})/i);console.log(dp,gp);"`


------
https://chatgpt.com/codex/tasks/task_e_684910a984dc83228efb6bfb7643844c